### PR TITLE
Fix some compiler warnings.

### DIFF
--- a/objecthash.c
+++ b/objecthash.c
@@ -200,6 +200,7 @@ bool object_hash(/*const*/ json_object *j, byte hash[HASH_SIZE]) {
   }
   printf("type = %d\n", type);
   assert(false);
+  return false;
 }
 
 bool python_json_hash(const char * const json, hash hash) {

--- a/objecthash.h
+++ b/objecthash.h
@@ -11,3 +11,4 @@ typedef byte hash[HASH_SIZE];
 typedef SHA256_CTX hash_ctx;
 
 bool common_json_hash(const char *json, hash h);
+bool python_json_hash(const char * const json, hash hash);

--- a/objecthash_test.c
+++ b/objecthash_test.c
@@ -36,8 +36,18 @@ static void run_test(const char * const json, const char * const h) {
 }
 
 int main(int argc, char **argv) {
+  run_test("[]",
+     "acac86c0e609ca906f632b0e2dacccb2b77d22b0621f20ebece1a4835b93f6f0");
+  run_test("[\"foo\"]",
+     "268bc27d4974d9d576222e4cdbb8f7c6bd6791894098645a19eeca9c102d0964");
   run_test("[\"foo\", \"bar\"]",
 	   "32ae896c413cfdc79eec68be9139c86ded8b279238467c216cf2bec4d5f1e4a2");
+  run_test("{}",
+     "18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4");
+  run_test("{\"foo\": \"bar\"}\"",
+     "7ef5237c3027d6c58100afadf37796b3d351025cf28038280147d42fdc53b960");
+  run_test("{\"foo\": [\"bar\", \"baz\"], \"qux\": [\"norf\"]}",
+     "f1a9389f27558538a064f3cc250f8686a0cebb85f1cab7f4d4dcc416ceda3c92");
   run_test("[\"foo\", {\"bar\": [\"baz\", null, 1.0, 1.5, 0.0001, 1000.0, 2.0, -23.1234, 2.0]}]",
 	   "783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213");
   run_test("[\"foo\", {\"bar\": [\"baz\", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]",


### PR DESCRIPTION
'Control reaches end of non-void function' in bool object_hash() in objecthash.c
'implicit declaration of function ‘python_json_hash’' in objecthash_test.c