### PR TITLE
Format madness

### DIFF
--- a/objecthash.c
+++ b/objecthash.c
@@ -1,3 +1,4 @@
+#include <alloca.h>
 #include <assert.h>
 #include <json-c/json.h>
 #include <stdio.h>

--- a/objecthash.c
+++ b/objecthash.c
@@ -21,7 +21,7 @@ static void hash_update(hash_ctx * const c, const byte * const b,
 
 static void hash_init(hash_ctx * const c, const byte t) {
   SHA256_Init(c);
-  
+
   byte b[1];
   b[0] = t;
   hash_update(c, b, 1);
@@ -250,16 +250,16 @@ static json_object *unicode_normalize_string(json_object *j) {
     const UNormalizer2 *un = unorm2_getNFCInstance(&err);
     assert(un);
     assert(!err);
-    
+
     int32_t length;
     u_strFromUTF8(NULL, 0, &length, s, strlen(s), &err);
     assert(!err);
-    
+
     UChar *us = alloca(length * sizeof(UChar));
     int32_t uslength;
     u_strFromUTF8(us, length, &uslength, s, strlen(s), &err);
     assert(!err);
-    
+
     // FIXME: surely we can find out how long the result will be?
     UChar *usn = alloca(uslength * 10 * sizeof(UChar));
     int32_t usnlength = unorm2_normalize(un, us, uslength, usn, 10 * uslength,

--- a/objecthash.c
+++ b/objecthash.c
@@ -1,6 +1,7 @@
 #include <alloca.h>
 #include <assert.h>
 #include <json-c/json.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -79,7 +80,7 @@ static bool object_hash_dict(/*const*/ json_object * const d, hash h) {
 static bool object_hash_int(int64_t i, hash h) {
   char buf[100];
 
-  sprintf(buf, "%ld", i);
+  sprintf(buf, "%" PRId64, i);
   hash_bytes('i', (byte *)buf, strlen(buf), h);
   return true;
 }


### PR DESCRIPTION
Try to make the sprintf format string more portable (it currently fails to compile on OS X/clang - see #11)