### PR TITLE
Don't use <alloca.h>.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@ java:
 	sbt compile
 	sbt test
 
-objecthash_test: objecthash_test.c objecthash.c
-	$(CC) -std=c99 -Wall -Werror -o objecthash_test objecthash_test.c objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c`
+objecthash_test: libobjecthash.so
+	$(CC) -std=c99 -Wall -Werror -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,.
+
+libobjecthash.so: objecthash.c
+	$(CC) -fPIC -shared -std=c99 -Wall -Werror -o libobjecthash.so objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c`
 
 get:
 	GOPATH=`pwd` go get golang.org/x/text/unicode/norm

--- a/objecthash.c
+++ b/objecthash.c
@@ -1,8 +1,8 @@
-#include <alloca.h>
 #include <assert.h>
 #include <json-c/json.h>
 #include <inttypes.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "unicode/utypes.h"


### PR DESCRIPTION
<alloca.h> is nonportable - it doesn't work on eg FreeBSD.  Use
the standard <stdlib.h> instead.