### PR TITLE
Give go code it's own package directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 *.pyc
+*.swp
 pkg/
 src/
 objecthash_test

--- a/go/objecthash/objecthash.go
+++ b/go/objecthash/objecthash.go
@@ -164,7 +164,7 @@ func ObjectHash(o interface{}) [hashLength]byte {
 	case bool:
 		return hashBool(v)
 	default:
-		panic(o)
+		panic(fmt.Sprintf("Unsupported type: %T", o))
 	}
 }
 

--- a/go/objecthash/objecthash.go
+++ b/go/objecthash/objecthash.go
@@ -11,17 +11,10 @@ import "sort"
 const hashLength int = sha256.Size
 
 func hash(t string, b []byte) [hashLength]byte {
-	//fmt.Printf("%x %x\n", []byte(t), b)
-	h := sha256.New()
-	h.Write([]byte(t))
-	h.Write(b)
-	// FIXME: Seriously, WTF?
-	var r []byte
-	r = h.Sum(r)
-	var rr [hashLength]byte
-	copy(rr[:], r)
-	//fmt.Printf("= %x\n", rr)
-	return rr;
+	var buf bytes.Buffer
+	buf.WriteString(t)
+	buf.Write(b)
+	return sha256.Sum256(buf.Bytes())
 }
 
 // FIXME: if What You Hash Is What You Get, then this needs to be safe
@@ -30,8 +23,9 @@ func hash(t string, b []byte) [hashLength]byte {
 type Set []interface{}
 
 type sortableHashes [][hashLength]byte
-func (h sortableHashes) Len() int { return len(h) }
-func (h sortableHashes) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h sortableHashes) Len() int           { return len(h) }
+func (h sortableHashes) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
 func (h sortableHashes) Less(i, j int) bool { return bytes.Compare(h[i][:], h[j][:]) < 0 }
 
 func hashSet(s Set) [hashLength]byte {
@@ -70,12 +64,15 @@ type hashEntry struct {
 	vhash [hashLength]byte
 }
 type byKHash []hashEntry
-func (h byKHash) Len() int { return len(h) }
-func (h byKHash) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
-func (h byKHash) Less(i, j int) bool { return bytes.Compare(h[i].khash[:],
-	h[j].khash[:]) < 0 }
 
-func hashDict(d map[string]interface {}) [hashLength]byte {
+func (h byKHash) Len() int      { return len(h) }
+func (h byKHash) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+func (h byKHash) Less(i, j int) bool {
+	return bytes.Compare(h[i].khash[:],
+		h[j].khash[:]) < 0
+}
+
+func hashDict(d map[string]interface{}) [hashLength]byte {
 	e := make([]hashEntry, len(d))
 	n := 0
 	for k, v := range d {
@@ -121,10 +118,10 @@ func floatNormalize(f float64) (s string) {
 		} else {
 			s += `0`
 		}
-		if (f >= 1) {
+		if f >= 1 {
 			panic(f)
 		}
-		if (len(s) >= 1000) {
+		if len(s) >= 1000 {
 			panic(s)
 		}
 		f *= 2
@@ -154,7 +151,7 @@ func ObjectHash(o interface{}) [hashLength]byte {
 		return hashList(v)
 	case string:
 		return hashUnicode(v)
-	case map[string]interface {}:
+	case map[string]interface{}:
 		return hashDict(v)
 	case float64:
 		return hashFloat(v)

--- a/go/objecthash/objecthash_test.go
+++ b/go/objecthash/objecthash_test.go
@@ -5,6 +5,8 @@ import "fmt"
 import "os"
 import "testing"
 
+const testFile = "../../common_json.test"
+
 func commonJSON(j string) {
 	fmt.Printf("%x\n", CommonJSONHash(j))
 }
@@ -16,7 +18,7 @@ func ExampleCommonJSONHash_Common() {
 
 func ExampleCommonJSONHash_FloatAndInt() {
 	commonJSON(`["foo", {"bar":["baz", null, 1.0, 1.5, 0.0001, 1000.0, 2.0, -23.1234, 2.0]}]`)
-        // Integers and floats are the same in common JSON
+	// Integers and floats are the same in common JSON
 	commonJSON(`["foo", {"bar":["baz", null, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2]}]`)
 	// Output:
 	// 783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213
@@ -35,6 +37,7 @@ func ExampleCommonJSONHash_KeyOrderIndependence() {
 	// ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057
 	// ddd65f1f7568269a30df7cafc26044537dc2f02a1a0d830da61762fc3e687057
 }
+
 /*
 func ExampleCommonJSONHash_UnicodeNormalisation() {
 	commonJSON("\"\u03d3\"")
@@ -68,7 +71,7 @@ func ExampleObjectHash_JSON2() {
 }
 
 func ExampleObjectHash_Set() {
-        o := map[string]interface{}{`thing1`: map[string]interface{}{`thing2`: Set{1, 2, `s`}}, `thing3`: 1234.567 }
+	o := map[string]interface{}{`thing1`: map[string]interface{}{`thing2`: Set{1, 2, `s`}}, `thing3`: 1234.567}
 	objectHash(o)
 	// Output: 618cf0582d2e716a70e99c2f3079d74892fec335e3982eb926835967cb0c246c
 }
@@ -86,7 +89,7 @@ func ExampleObjectHash_ComplexSetRepeated() {
 }
 
 func TestGolden(t *testing.T) {
-	f, err := os.Open("common_json.test")
+	f, err := os.Open(testFile)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Makes the go code available via
`go get github.com/benlaurie/objecthash/go/objecthash`
- Package path conforms to standard Go conventions.  I.e. the directory and
  the package name should match.
- Resolves an issue where the go compiler was attempting to build the C
  files by giving the go code it's own directory.
- Cleans up the FIXME comments