### PR TITLE
Fix broken tests in go/objecthash

### DIFF
--- a/go/objecthash/objecthash_test.go
+++ b/go/objecthash/objecthash_test.go
@@ -47,24 +47,21 @@ func ExampleCommonJSONHash_UnicodeNormalisation() {
 	// f72826713a01881404f34975447bd6edcb8de40b191dc57097ebf4f5417a554d
 }
 */
-func objectHash(o interface{}) {
-	fmt.Printf("%x\n", ObjectHash(o))
-}
 
 func ExampleObjectHash_JSON() {
 	// Same as equivalent JSON object
 	o := []interface{}{`foo`, `bar`}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Output: 32ae896c413cfdc79eec68be9139c86ded8b279238467c216cf2bec4d5f1e4a2
 }
 
 func ExampleObjectHash_JSON2() {
 	// Same as equivalent _Python_ JSON object
 	o := []interface{}{`foo`, map[string]interface{}{`bar`: []interface{}{`baz`, nil, 1, 1.5, 0.0001, 1000, 2, -23.1234, 2}}}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Same as equivalent Common JSON object
 	o = []interface{}{`foo`, map[string]interface{}{`bar`: []interface{}{`baz`, nil, 1.0, 1.5, 0.0001, 1000.0, 2.0, -23.1234, 2.0}}}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Output:
 	// 726e7ae9e3fadf8a2228bf33e505a63df8db1638fa4f21429673d387dbd1c52a
 	// 783a423b094307bcb28d005bc2f026ff44204442ef3513585e7e73b66e3c2213
@@ -72,19 +69,19 @@ func ExampleObjectHash_JSON2() {
 
 func ExampleObjectHash_Set() {
 	o := map[string]interface{}{`thing1`: map[string]interface{}{`thing2`: Set{1, 2, `s`}}, `thing3`: 1234.567}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Output: 618cf0582d2e716a70e99c2f3079d74892fec335e3982eb926835967cb0c246c
 }
 
 func ExampleObjectHash_ComplexSet() {
 	o := Set{`foo`, 23.6, Set{Set{}}, Set{Set{1}}}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Output: 3773b0a5283f91243a304d2bb0adb653564573bc5301aa8bb63156266ea5d398
 }
 
 func ExampleObjectHash_ComplexSetRepeated() {
 	o := Set{`foo`, 23.6, Set{Set{}}, Set{Set{1}}, Set{Set{}}}
-	objectHash(o)
+	fmt.Printf("%x\n", objectHash(o))
 	// Output: 3773b0a5283f91243a304d2bb0adb653564573bc5301aa8bb63156266ea5d398
 }
 


### PR DESCRIPTION
Pull Request #19 defines `objectHash` in `go/objecthash/objecthash.go` while a function in the same name already exists in the same package (in `go/objecthash/objecthash_test.go`). This Pull Request fixes failed `go test ./...` in `go/objecthash`.
