### PR TITLE
Fix the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
+.PHONY: test go python c java go_deps
+
 test: c go python java
 
-go:
-	GOPATH=`pwd` go test -v objecthash.go objecthash_test.go
+go: go_deps
+	GOPATH=`pwd` go test -v \
+				 go/objecthash/objecthash.go \
+				 go/objecthash/objecthash_test.go
 
 python:
 	python objecthash_test.py
@@ -13,11 +17,11 @@ java:
 	sbt compile
 	sbt test
 
-objecthash_test: libobjecthash.so
+objecthash_test: libobjecthash.so objecthash_test.c
 	$(CC) -std=c99 -Wall -Werror -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,.
 
 libobjecthash.so: objecthash.c
 	$(CC) -fPIC -shared -std=c99 -Wall -Werror -o libobjecthash.so objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c`
 
-get:
+go_deps:
 	GOPATH=`pwd` go get golang.org/x/text/unicode/norm


### PR DESCRIPTION
- Declare all non-file targets as `.PHONY` to avoid conflicts with files
  of the same name (Fixes #26).
- Fix the "go" test target's command, which was broken after files were
  moved into the `go` directory.
- Add `objecthash_test.c` as a dependency for `objecthash_test`.
- Rename `get` to `go_deps` to make it more clear.