### PR TITLE
Add ObjectHash Test

### DIFF
--- a/go/objecthash/objecthash_test.go
+++ b/go/objecthash/objecthash_test.go
@@ -118,3 +118,19 @@ func TestGolden(t *testing.T) {
 		}
 	}
 }
+
+func TestObjectHash(t *testing.T) {
+	for _, tc := range []struct {
+		o    interface{}
+		want [hashLength]byte
+	}{
+		{
+			o:    struct{ Name string }{Name: "bob"},
+			want: [hashLength]byte{},
+		},
+	} {
+		if got, want := ObjectHash(tc.o), tc.want; got != want {
+			t.Errorf("objectHash(%#v): %x, want %x", tc.o, got, want)
+		}
+	}
+}


### PR DESCRIPTION
`ObjectHash` has the a function comment of 
```
// ObjectHash returns the hash of an arbirary Go object.
```

This PR creates a test with a few example Go objects. 

The test for a simple struct produces a panic. 
Is this expected or unexpected behavior? 

```
ObjectHash(struct { Name string }{name: "bob"})

panic: Unsupported type: struct { Name string } [recovered]
	panic: Unsupported type: struct { Name string }
```

