### PR TITLE
Improve the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+.PHONY: test go_test python c java go_deps
+
 test: c go_test python java
 
-go_test:
+go_test: go_deps
 	GOPATH=`pwd` go test -v go/objecthash/objecthash.go go/objecthash/objecthash_test.go
 
 python:
@@ -14,11 +16,11 @@ java:
 #	sbt compile
 #	sbt test
 
-objecthash_test: libobjecthash.so
+objecthash_test: libobjecthash.so objecthash_test.c
 	$(CC) -std=c99 -Wall -Werror -Wextra -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,. `pkg-config --libs --cflags icu-uc json-c openssl`
 
 libobjecthash.so: objecthash.c
 	$(CC) -fPIC -shared -std=c99 -Wall -Werror -Wextra -o libobjecthash.so objecthash.c -lcrypto `pkg-config --libs --cflags icu-uc json-c openssl`
 
-get:
+go_deps:
 	GOPATH=`pwd` go get golang.org/x/text/unicode/norm


### PR DESCRIPTION
- Declare all non-file targets as `.PHONY` to avoid potential conflicts
  with files of the same name (ex. #26).
- Add `objecthash_test.c` as a dependency for `objecthash_test`.
- Rename `get` to `go_deps` to make it more clear.
- Add `go_deps` as a dependency for `go_test`.