### PR TITLE
Fixed #45 by allowing hashing of special float values.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: test go_test python c java go_deps
+.PHONY: test go_test ruby python c java go_deps
 
-test: c go_test python java
+test: c go_test ruby python java
 
 go_test: go_deps
 	GOPATH=`pwd` go test -v go/objecthash/objecthash.go go/objecthash/objecthash_test.go
+
+ruby:
+	cd ruby && rake
 
 python:
 	python objecthash_test.py

--- a/go/objecthash/objecthash.go
+++ b/go/objecthash/objecthash.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"sort"
 )
@@ -153,10 +154,23 @@ func floatNormalize(originalFloat float64) (s string, err error) {
 }
 
 func hashFloat(f float64) ([hashLength]byte, error) {
-	normalizedFloat, err := floatNormalize(f)
-	if err != nil {
-		return [hashLength]byte{}, err
+	var normalizedFloat string
+
+	switch {
+	case math.IsInf(f, 1):
+		normalizedFloat = "Infinity"
+	case math.IsInf(f, -1):
+		normalizedFloat = "-Infinity"
+	case math.IsNaN(f):
+		normalizedFloat = "NaN"
+	default:
+		var err error
+		normalizedFloat, err = floatNormalize(f)
+		if err != nil {
+			return [hashLength]byte{}, err
+		}
 	}
+
 	return hash(`f`, []byte(normalizedFloat)), nil
 }
 

--- a/go/objecthash/objecthash_test.go
+++ b/go/objecthash/objecthash_test.go
@@ -3,6 +3,7 @@ package objecthash
 import (
 	"bufio"
 	"fmt"
+	"math"
 	"os"
 	"testing"
 )
@@ -231,6 +232,21 @@ func ExampleObjectHash_Maps() {
 	// 18ac3e7343f016890c510e93f935261169d9e3f565436429830faf0934f4f8e4
 	// 1909a37b5f94b2b7760fc5f5a76eee66a8907e71ba3281831927c19dfe8c1801
 	// 1eb24844c2bb924515efd56f3310d875a3aeaef54d690186d698bfd926a93322
+}
+
+func ExampleObjectHash_SpecialFloatValues() {
+	nan := math.NaN()
+	printObjectHash(nan)
+
+	pinf := math.Inf(1)
+	printObjectHash(pinf)
+
+	ninf := math.Inf(-1)
+	printObjectHash(ninf)
+	// Output:
+	// 5d6c301a98d835732d459d7018a8d546872f7ba3c39a45ba481746d2c6d566d9
+	// e0309b2362dc6aaf595338cd9e116761640f74927bcdc4f76e8e6433738f25c7
+	// 1167518d5554ba86d9b176af0a57f29d425bedaa9847c245cc397b37533228f7
 }
 
 func ExampleObjectHash_UnsupportedType() {

--- a/objecthash.py
+++ b/objecthash.py
@@ -1,5 +1,6 @@
 import json
 import hashlib
+import math
 import random
 import types
 import unicodedata
@@ -88,7 +89,12 @@ def float_normalize(f):
     return s
 
 def obj_hash_float(f):
-    return hash_primitive('f', float_normalize(f))
+    if math.isnan(f):
+        return hash_primitive('f', 'NaN')
+    elif math.isinf(f):
+        return hash_primitive('f', 'Infinity' if f > 0 else '-Infinity')
+    else:
+        return hash_primitive('f', float_normalize(f))
 
 def obj_hash_int(i):
     return hash_primitive('i', str(i))

--- a/objecthash_test.py
+++ b/objecthash_test.py
@@ -114,6 +114,11 @@ class TestObjectHash(unittest.TestCase):
         self.verify(0.0, '60101d8c9cb988411468e38909571f357daa67bff5a7b0a3f9ae295cd4aba33d')
         self.verify(-0.0, '60101d8c9cb988411468e38909571f357daa67bff5a7b0a3f9ae295cd4aba33d')
 
+    def test_float_special_values(self):
+        self.verify(float("nan"), '5d6c301a98d835732d459d7018a8d546872f7ba3c39a45ba481746d2c6d566d9')
+        self.verify(float("inf"), 'e0309b2362dc6aaf595338cd9e116761640f74927bcdc4f76e8e6433738f25c7')
+        self.verify(float("-inf"), '1167518d5554ba86d9b176af0a57f29d425bedaa9847c245cc397b37533228f7')
+
 
 class TestRedaction(unittest.TestCase):
     def verify(self, o, e):

--- a/ruby/lib/objecthash.rb
+++ b/ruby/lib/objecthash.rb
@@ -129,7 +129,13 @@ class ObjectHash
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def obj_hash_float(f)
-    hash_primitive("f", float_normalize(f))
+    if f.nan?
+      hash_primitive("f", "NaN")
+    elsif f.infinite?
+      hash_primitive("f", f.positive? ? "Infinity" : "-Infinity")
+    else
+      hash_primitive("f", float_normalize(f))
+    end
   end
 
   def obj_hash_int(i)

--- a/ruby/spec/objecthash_spec.rb
+++ b/ruby/spec/objecthash_spec.rb
@@ -214,6 +214,10 @@ RSpec.describe ObjectHash do
         expect(described_class.hexdigest(1000.0)).to eq "09b29bf3f8bea85fbf7dd5b3e185e9c3a007761f8824a54d4d518578c9360419"
         expect(described_class.hexdigest(1.2345)).to eq "844e08b1195a93563db4e5d4faa59759ba0e0397caf065f3b6bc0825499754e0"
         expect(described_class.hexdigest(-10.1234)).to eq "59b49ae24998519925833e3ff56727e5d4868aba4ecf4c53653638ebff53c366"
+        # Special values.
+        expect(described_class.hexdigest(Float::NAN)).to eq "5d6c301a98d835732d459d7018a8d546872f7ba3c39a45ba481746d2c6d566d9"
+        expect(described_class.hexdigest(Float::INFINITY)).to eq "e0309b2362dc6aaf595338cd9e116761640f74927bcdc4f76e8e6433738f25c7"
+        expect(described_class.hexdigest(-Float::INFINITY)).to eq "1167518d5554ba86d9b176af0a57f29d425bedaa9847c245cc397b37533228f7"
       end
     end
   end


### PR DESCRIPTION
This was done for almost all implementations in the repository. The only
two exceptions are Java and C. This is because special float values are
not available in JSON and those implementations use JSON objects and not
arbitrary objects.

Also, add ruby to the test suites that the Makefile runs.