### PR TITLE
Commonjson.test alignment for golang, java and python. Redacted functionality for java.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,28 @@
 *.swp
 *.so
 pkg/
-src/
 # made by sbt
 project/
 objecthash_test
+
+# OSX
+.DS_Store
+
+# IDE
+.idea
+*.iml
+
+# Maven
+.mvn
+
+*.class
+out/
+target/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,10 @@ matrix:
     - cd ruby
     - bundle
     - bundle exec rake
+  - language: java
+    jdk: openjdk8
+  - language: python
+    python:
+      - "2.7"
+    script:
+      - make python

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: test go_test ruby python c java go_deps
 
-test: c go_test ruby python java
+PKG_CONFIG_PATH=/usr/local/opt/icu4c/lib/pkgconfig
+
+test: c ruby go_test python java
 
 go_test: go_deps
 	GOPATH=`pwd` go test -timeout 1m -v go/objecthash/objecthash.go go/objecthash/objecthash_test.go
@@ -15,9 +17,8 @@ c: objecthash_test
 	./objecthash_test
 
 java:
-# FIXME: sbt seems to not work with JDK 1.9.1
-#	sbt compile
-#	sbt test
+	sbt compile
+	sbt test
 
 objecthash_test: libobjecthash.so objecthash_test.c
 	$(CC) -std=c99 -Wall -Werror -Wextra -o objecthash_test objecthash_test.c -lobjecthash -L. -Wl,-rpath -Wl,. `pkg-config --libs --cflags icu-uc json-c openssl`

--- a/go/objecthash/objecthash_test.go
+++ b/go/objecthash/objecthash_test.go
@@ -271,7 +271,7 @@ func TestGolden(t *testing.T) {
 				return
 			}
 			j = s.Text()
-			if len(j) != 0 && j[0] != '#' {
+			if len(j) != 0 && j[0] != '#' && j[0] != '~' {
 				break
 			}
 		}

--- a/objecthash_test.py
+++ b/objecthash_test.py
@@ -42,7 +42,7 @@ class TestCommonJSONHash(unittest.TestCase):
             while True:
                 while True:
                     j = f.readline()
-                    if not j or (not j.startswith('#') and j[0] != '\n'):
+                    if not j or (not j.startswith('#') and not j.startswith('~') and j[0] != '\n'):
                         break
                 if not j:
                     break

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,54 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.links.objecthash</groupId>
+    <artifactId>objecthash</artifactId>
+    <version>0.1</version>
+    <packaging>jar</packaging>
+
+    <name>objecthash</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.novocode</groupId>
+            <artifactId>junit-interface</artifactId>
+            <version>0.8</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20090211</version>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/src/main/java/org/links/objecthash/Redacted.java
+++ b/src/main/java/org/links/objecthash/Redacted.java
@@ -1,0 +1,26 @@
+package org.links.objecthash;
+
+import java.security.NoSuchAlgorithmException;
+
+// TODO: should just extend ObjectHash probably
+public class Redacted {
+  static final String PREFIX = "**REDACTED**";
+  private ObjectHash hash;
+
+  public Redacted(ObjectHash hash) {
+    this.hash = hash;
+  }
+
+  public static Redacted fromString(String repesentation) throws NoSuchAlgorithmException {
+    return new Redacted(ObjectHash.fromHex(repesentation.replace(PREFIX, "")));
+  }
+
+  public byte[] hash() {
+    return this.hash.hash();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s%s", PREFIX, hash.toString());
+  }
+}


### PR DESCRIPTION
I needed to use Redacted objecthash functionality in my java library that works with golang serverside. After successful implementation it I've ran all tests and realized that those libs provide different results for different data structures. It doesn't really breaks anything for my as I'm mostly working with strings, but I decided to align test results to match golang commonjson.test testcases. So that's what I did. I hope it'll help. Some java tests were conflicting with commonjson.test testcases, so I've iligned them, but decided not to remove.

* Fixed java tests to pass same tests as go does
* Fixed python tests to pass same tests as go does
* Added pom files for convenient work with java version
* Fixed tests to ignore first line of commonjson.test file
* Removed java root from .gitignore

NOTE: I was able to run tests for Python, Java and golang. I wasn't able to build c code and I always get confused while working with ruby, so I left those unchanged, BUT I didn't comment them out in Makefile. I hope this PR is useful.